### PR TITLE
Resolved overflow issue when multiple questions exceed the viewport height

### DIFF
--- a/src/app/components/ui/question.tsx
+++ b/src/app/components/ui/question.tsx
@@ -50,7 +50,7 @@ const Questions: React.FC<QuestionsProps> = ({ questions }) => {
   };
 
   return (
-    <div className="grid grid-cols-1 gap-4 px-4 py-2">
+    <div className="grid grid-cols-1 gap-4 px-4 py-2 md:h-full">
       {questions.map((q: any, i: number) => (
         <div key={i} className="bg-gray-100 dark:bg-slate-800 p-4 rounded">
           <h3 className="text-sm sm:text-lg font-medium py-2">{q?.question}</h3>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -160,7 +160,7 @@ export default function Home() {
         </div>
 
         {/* Questions */}
-        <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-8 md:h-[95vh]">
           {loading ? (
             <>
               <div className="animate-pulse h-42 bg-gray-200 dark:bg-slate-800 rounded mt-1 p-4">
@@ -178,7 +178,7 @@ export default function Home() {
               <h2 className="text-center text-2xl sm:text-3xl font-bold">
                 Questions
               </h2>
-              <div className="flex justify-center items-center h-[85%] overflow-y-scroll py-4">
+              <div className="flex justify-center items-center overflow-y-scroll py-4">
                 <Questions questions={questionsList} />
               </div>
             </>


### PR DESCRIPTION
I observed that when there are multiple questions, such as 10, requiring the user to scroll, part of the first question was being cut off.

